### PR TITLE
Implemented SSH key for Github Integrator

### DIFF
--- a/gate-approval/custom-stage-deck/src/VisibilityApprovalConfig.tsx
+++ b/gate-approval/custom-stage-deck/src/VisibilityApprovalConfig.tsx
@@ -357,6 +357,10 @@ export function VisibilityApprovalConfig(props: IStageConfigProps) {
           const findIndex = accountsOptions.findIndex((specificAccountOption: any) => specificAccountOption[connectorName.toLowerCase()] == connectorName.toLowerCase());
           if (findIndex < 0) {
             let temp: any = {};
+             // For github connectors, supporting data that has only token  
+            if(connectorName.toLowerCase() == 'github') 
+              response = response.filter((acc : any) => acc.configurationFields.hasOwnProperty('token'))
+
             temp[connectorName.toLowerCase()] = response;
 
             let options = JSON.parse(localStorage.getItem('accountList')) ? JSON.parse(localStorage.getItem('accountList')) : [];


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-22258

Parent Jira: https://devopsmx.atlassian.net/browse/OP-22202

Test cases covered:

Integrations Page:
Authentication dropdown should display SSH Authentication along with Token - Pass
On select of ssh key , need to display two input text fields - File path and passphrase - Pass
File path is mandatory and Pass phrase is optional - Pass
Validate, Connect to CD and Test option should be disabled or hidden - Pass
After entering the required data, onclick of save it should save to Integrations - Pass

CD Integration Page:
For Source Control for Pipeline,
If the provider is GITHUB, Display accounts only if the authType is bearer - Pass

Approval Gate in Custom Plugins:
Need to display accounts only if the authType is bearer in the Approval Configuration if the selected configuration is GITHUB - Pass