### PR TITLE
OP-22934: Implemented code changes to make tag information available in the OPA runtime policy input.

### DIFF
--- a/gate-policy/custom-stage-orca/custom-stage-orca.gradle
+++ b/gate-policy/custom-stage-orca/custom-stage-orca.gradle
@@ -40,6 +40,8 @@ dependencies {
   compileOnly "io.spinnaker.kork:kork-plugins-api:${korkVersion}"
   compileOnly "io.spinnaker.orca:orca-api:${orcaVersion}"
   compileOnly "io.spinnaker.orca:orca-clouddriver:${orcaVersion}"
+  compileOnly "io.spinnaker.orca:orca-front50:${orcaVersion}"
+  compileOnly "io.spinnaker.orca:orca-core:${orcaVersion}"
   kapt "org.pf4j:pf4j:${pf4jVersion}"
 
   compileOnly group: 'com.squareup.retrofit', name: 'retrofit', version: '1.9.0'

--- a/gate-policy/custom-stage-orca/src/main/java/com/opsmx/plugin/stage/custom/PolicyTask.java
+++ b/gate-policy/custom-stage-orca/src/main/java/com/opsmx/plugin/stage/custom/PolicyTask.java
@@ -251,7 +251,7 @@ public class PolicyTask implements Task {
 		String appName = stage.getExecution().getApplication();
 		String pipelineName = stage.getExecution().getName();
 		Map<String, Object> pipeline = fetchPipelineInfo(appName, pipelineName);
-		logger.info("Pipeline Info: {}", pipeline);
+		logger.debug("Pipeline Info: {}", pipeline);
 
 		Object payloadContext = ((Map<String, Object>) stage.getContext().get("parameters")).get("payload");
 		Map<String, Object> parameterContext = (Map<String, Object>) stage.getContext().get("parameters");
@@ -282,7 +282,7 @@ public class PolicyTask implements Task {
 		if (pipeline != null && pipeline.containsKey("tags")) {
 			JsonNode tagsNode = objectMapper.convertValue(pipeline.get("tags"), JsonNode.class);
 			finalJson.set("tags", tagsNode);
-			logger.info("Tags added to finalJson: {}", tagsNode);
+			logger.debug("Tags added to finalJson: {}", tagsNode);
 		}
 		ArrayNode payloadConstraintNode = objectMapper.createArrayNode();
 		if (parameterContext.get("gateSecurity") != null) {


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-22934.

**Logs After getting pipeline info and adding to final json**

2024-12-10 10:54:32.683  DEBUG 1 --- [     handlers-4] c.opsmx.plugin.stage.custom.PolicyTask   : [user2] Pipeline Info: {id=869f7de7-29c3-46c2-aea8-891641847e64, name=p1, application=newapp7nov, schema=1, triggers=[], index=0, updateTs=1733498070000, lastModifiedBy=user2, stages=[{applicationId=10, name=Policy, parameters={customEnvironment=, environment=[{id=1, spinnakerEnvironment=default}], gateSecurity=[{connectorType=PayloadConstraints, helpText=Payload Constraints, isMultiSupported=true, label=Payload Constraints, selectInput=false, supportedParams=[{helpText=Key, label=Key, name=label, type=string}, {helpText=Value, label=Value, name=value, type=string}], values=[]}], policyId=5, policyName=TagPolicy}, pipelineId=52, refId=1, requisiteStageRefIds=[], serviceId=52, type=policy}], keepWaitingPipelines=false, limitConcurrent=true, spelEvaluator=v4, tags=[{name=asd, value=bapp123}]}
2024-12-10 10:54:32.684  DEBUG 1 --- [     handlers-4] c.opsmx.plugin.stage.custom.PolicyTask   : [user2] Tags added to finalJson: [{"name":"asd","value":"bapp123"}]