### PR TITLE
OP-22474: Implemented calling OPA failOpen url on timeout value set.

### DIFF
--- a/orca/build.gradle
+++ b/orca/build.gradle
@@ -21,7 +21,7 @@ spinnakerBundle {
   version = rootProject.version
 }
 
-version = "v1.0.3-SNAPSHOT"
+version = "v1.0.4-SNAPSHOT"
 
 subprojects {
   group = "com.opsmx.plugin.policy.runtime"

--- a/orca/custom-policy-orca/src/main/java/com/opsmx/plugin/policy/runtime/OpaConfigProperties.java
+++ b/orca/custom-policy-orca/src/main/java/com/opsmx/plugin/policy/runtime/OpaConfigProperties.java
@@ -88,4 +88,35 @@ public class OpaConfigProperties {
         }
     }
 
+    private FailOpen failOpen;
+
+    public FailOpen getFailOpen() {
+        return failOpen;
+    }
+
+    public void setFailOpen(FailOpen failOpen) {
+        this.failOpen = failOpen;
+    }
+
+    public static class FailOpen {
+        private boolean enabled = false;
+        private int timeout = 10;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public int getTimeout() {
+            return timeout;
+        }
+
+        public void setTimeout(int timeout) {
+            this.timeout = timeout;
+        }
+    }
+
 }

--- a/orca/custom-policy-orca/src/main/java/com/opsmx/plugin/policy/runtime/OpenPolicyAgentPreprocessor.java
+++ b/orca/custom-policy-orca/src/main/java/com/opsmx/plugin/policy/runtime/OpenPolicyAgentPreprocessor.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.ComponentScan;
+import java.util.concurrent.TimeUnit;
 
 import com.netflix.spinnaker.kork.web.exceptions.ValidationException;
 
@@ -121,7 +122,7 @@ public class OpenPolicyAgentPreprocessor implements ExecutionPreprocessor, Spinn
 				}
 			}
 
-		} } catch (IOException e) {
+		} catch (IOException e) {
 		e.printStackTrace();
 		logger.error("Communication exception for OPA at {}", opaConfigProperties.getUrl(), e);
 		logger.debug("End of the Policy Validation");
@@ -131,7 +132,7 @@ public class OpenPolicyAgentPreprocessor implements ExecutionPreprocessor, Spinn
 			return pipeline;
 		}
 		throw new ValidationException(e.toString(), null);
-	} } catch (Exception e) {
+	}  catch (Exception e) {
 		e.printStackTrace();
 			logger.error("Exception occured : {}", e);
 			logger.error("Some thing wrong While processing the OPA Validation, input : {}", pipeline);
@@ -143,6 +144,9 @@ public class OpenPolicyAgentPreprocessor implements ExecutionPreprocessor, Spinn
         }
 			throw new ValidationException(e.toString(), null);
 		}
+		logger.debug("End of the Policy Validation");
+		return pipeline;
+	}
 
 	private boolean isChildPipeline(Map<String, Object> pipeline) {
 		if( pipeline.containsKey("trigger") ) {

--- a/orca/custom-policy-orca/src/main/java/com/opsmx/plugin/policy/runtime/OpenPolicyAgentPreprocessor.java
+++ b/orca/custom-policy-orca/src/main/java/com/opsmx/plugin/policy/runtime/OpenPolicyAgentPreprocessor.java
@@ -71,6 +71,18 @@ public class OpenPolicyAgentPreprocessor implements ExecutionPreprocessor, Spinn
 			logger.debug("End of the Policy Validation");
 			return pipeline;
 		}
+		if (opaConfigProperties.getFailOpen() != null
+				&& opaConfigProperties.getFailOpen().isEnabled()) {
+
+			boolean reachable = checkOpaReachability(
+					opaConfigProperties.getUrl(),
+					opaConfigProperties.getFailOpen().getTimeout()
+			);
+			if (!reachable) {
+				logger.warn("OPA not reachable, but failOpen enabled. Proceeding with pipeline execution.");
+				return pipeline;
+			}
+		}
 		try {
 			/*if(isChildPipeline(pipeline)){
 				logger.debug("This pipeline is a child pipeline and trigger by parent ");
@@ -109,21 +121,28 @@ public class OpenPolicyAgentPreprocessor implements ExecutionPreprocessor, Spinn
 				}
 			}
 
-		} catch (IOException e) {
-			e.printStackTrace();
-			logger.error("Communication exception for OPA at {}: {}", opaConfigProperties.getUrl(), e.toString());
-			logger.debug("End of the Policy Validation");
-			throw new ValidationException(e.toString(), null);
-		} catch (Exception e) {
-			e.printStackTrace();
+		} } catch (IOException e) {
+		e.printStackTrace();
+		logger.error("Communication exception for OPA at {}", opaConfigProperties.getUrl(), e);
+		logger.debug("End of the Policy Validation");
+		if (opaConfigProperties.getFailOpen() != null
+				&& opaConfigProperties.getFailOpen().isEnabled()) {
+			logger.warn("OPA communication failed, but failOpen enabled. Proceeding.");
+			return pipeline;
+		}
+		throw new ValidationException(e.toString(), null);
+	} } catch (Exception e) {
+		e.printStackTrace();
 			logger.error("Exception occured : {}", e);
 			logger.error("Some thing wrong While processing the OPA Validation, input : {}", pipeline);
 			logger.debug("End of the Policy Validation");
+		if (opaConfigProperties.getFailOpen() != null
+		&& opaConfigProperties.getFailOpen().isEnabled()) {
+		logger.warn("OPA communication failed, but failOpen enabled. Proceeding.");
+        return pipeline;
+        }
 			throw new ValidationException(e.toString(), null);
 		}
-		logger.debug("End of the Policy Validation");
-		return pipeline;
-	}
 
 	private boolean isChildPipeline(Map<String, Object> pipeline) {
 		if( pipeline.containsKey("trigger") ) {
@@ -133,6 +152,27 @@ public class OpenPolicyAgentPreprocessor implements ExecutionPreprocessor, Spinn
 			}
 		}
 		return false;
+	}
+
+	private boolean checkOpaReachability(String opaUrl, int timeoutSeconds) {
+		try {
+			OkHttpClient client = new OkHttpClient.Builder()
+					.connectTimeout(timeoutSeconds, TimeUnit.SECONDS)
+					.readTimeout(timeoutSeconds, TimeUnit.SECONDS)
+					.build();
+
+			Request request = new Request.Builder()
+					.url(opaUrl)
+					.get()
+					.build();
+
+			try (Response response = client.newCall(request).execute()) {
+				return response.code() < 500;
+			}
+		} catch (Exception e) {
+			logger.error("OPA reachability check failed", e);
+			return false;
+		}
 	}
 
 	private void validateOPAResponse(String opaStringResponse){


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-22474


**Feature implemented for runtime policy validation** 

- Added a configuration flag to control fail-open behaviour with timeout.
- When enabled, Orca-runtime-policy-plugin performs a lightweight reachability check directly against the configured OPA URL within the specified timeout.
- If the OPA endpoint is unreachable or the request times out, the pipeline proceeds execution without terminating.


**config**

```
policy:
  opa:
    failOpen:
      enabled: true
      timeout: 10
```
